### PR TITLE
Add missing dhcpd.conf.j2 template

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ The following defaults variables can be configured:
   isc_dhcp_server_subnet:
     - netaddress: 192.168.121.0
       netmask: 255.255.255.0
-      gateway: 192.168.121.1
+      routers: 192.168.121.1
       domain: lab.local
       domain_search: lab.local
       dns: 192.168.121.1

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,7 +13,7 @@ isc_dhcp_server_subnet: []
 #   isc_dhcp_server_subnet:
 #     - netaddress: 192.168.121.0
 #       netmask: 255.255.255.0
-#       gateway: 192.168.121.1
+#       routers: 192.168.121.1
 #       domain: lab.local
 #       domain_search: lab.local
 #       dns: 192.168.121.1

--- a/templates/dhcpd.conf.j2
+++ b/templates/dhcpd.conf.j2
@@ -1,0 +1,19 @@
+# {{ ansible_managed }}
+
+omapi-port {{ isc_dhcp_server_omapi_port }};
+ddns-update-style none;
+
+default-lease-time 600;
+max-lease-time 7200;
+log-facility local7;
+
+{% for item in isc_dhcp_server_subnet %}
+subnet {{ item.netaddress }} netmask {{ item.netmask }} {
+    option routers               {{ item.routers }};
+    option domain-name           "{{ item.domain }}";
+    option domain-search         "{{ item.domain_search }}";
+    option domain-name-servers   {{ item.dns }};
+    range                        {{ item.range }};
+}
+
+{% endfor %}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This PR fixes #4  by adding the missing dhcpd.conf.j2 template. In addition the gateway variable was renamed to routers to better fit into the expected rendered configuration.
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.8.3
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
n/a
```
